### PR TITLE
feat: add gas and skipSimulation params to sendTransaction

### DIFF
--- a/.changeset/sparkly-rules-yell.md
+++ b/.changeset/sparkly-rules-yell.md
@@ -1,0 +1,5 @@
+---
+"@gelatocloud/gasless": patch
+---
+
+feat: skip simulation

--- a/examples/account/sponsored/src/index.ts
+++ b/examples/account/sponsored/src/index.ts
@@ -63,7 +63,8 @@ const main = async () => {
     /**
      * (Optional) Here you may specify a nonce or nonceKey
      */
-    nonce: encodeNonce(BigInt(Date.now()), 0n)
+    nonce: encodeNonce(BigInt(Date.now()), 0n),
+    skipSimulation: true
   });
 
   const end = Date.now();

--- a/examples/account/sponsored/src/index.ts
+++ b/examples/account/sponsored/src/index.ts
@@ -63,8 +63,7 @@ const main = async () => {
     /**
      * (Optional) Here you may specify a nonce or nonceKey
      */
-    nonce: encodeNonce(BigInt(Date.now()), 0n),
-    skipSimulation: true
+    nonce: encodeNonce(BigInt(Date.now()), 0n)
   });
 
   const end = Date.now();

--- a/src/account/actions/sendTransaction.test.ts
+++ b/src/account/actions/sendTransaction.test.ts
@@ -92,6 +92,28 @@ describe('sendTransaction', () => {
     expect(account.getNonce).toHaveBeenCalledWith({ key: 5n });
   });
 
+  it('passes gas and skipSimulation through to client.sendTransaction', async () => {
+    const account = createMockSmartAccount();
+
+    await sendTransaction(mockClient as never, account as never, {
+      calls: [{ to: MOCK_ADDRESS, value: 0n }],
+      gas: 100000n,
+      skipSimulation: true
+    });
+
+    expect(mockClient.sendTransaction).toHaveBeenCalledWith(
+      {
+        authorizationList: undefined,
+        chainId: 1,
+        data: MOCK_CALL_DATA,
+        gas: 100000n,
+        skipSimulation: true,
+        to: MOCK_ADDRESS
+      },
+      undefined
+    );
+  });
+
   it('passes retries option through to client.sendTransaction', async () => {
     const account = createMockSmartAccount();
 

--- a/src/account/actions/sendTransaction.ts
+++ b/src/account/actions/sendTransaction.ts
@@ -19,6 +19,8 @@ export type NonceOrKey =
 
 export type SendTransactionParameters = NonceOrKey & {
   calls: Call[];
+  gas?: bigint;
+  skipSimulation?: boolean;
 };
 
 export const sendTransaction = async (
@@ -27,7 +29,7 @@ export const sendTransaction = async (
   parameters: SendTransactionParameters,
   options?: SendTransactionOptions
 ): Promise<Hex> => {
-  const { calls } = parameters;
+  const { calls, gas, skipSimulation } = parameters;
 
   const [nonce, deployed] = await Promise.all([
     parameters.nonce ?? account.getNonce({ key: parameters.nonceKey }),
@@ -44,6 +46,8 @@ export const sendTransaction = async (
       authorizationList,
       chainId: account.chain.id,
       data,
+      gas,
+      skipSimulation,
       to: account.address
     },
     options

--- a/src/account/actions/sendTransactionSync.test.ts
+++ b/src/account/actions/sendTransactionSync.test.ts
@@ -77,6 +77,28 @@ describe('sendTransactionSync', () => {
     );
   });
 
+  it('passes gas and skipSimulation through to client.sendTransactionSync', async () => {
+    const account = createMockSmartAccount();
+
+    await sendTransactionSync(mockClient as never, account as never, {
+      calls: [{ to: MOCK_ADDRESS, value: 0n }],
+      gas: 100000n,
+      skipSimulation: true
+    });
+
+    expect(mockClient.sendTransactionSync).toHaveBeenCalledWith(
+      {
+        authorizationList: undefined,
+        chainId: 1,
+        data: MOCK_CALL_DATA,
+        gas: 100000n,
+        skipSimulation: true,
+        to: MOCK_ADDRESS
+      },
+      undefined
+    );
+  });
+
   it('passes retries option through to client.sendTransactionSync', async () => {
     const account = createMockSmartAccount();
 

--- a/src/account/actions/sendTransactionSync.ts
+++ b/src/account/actions/sendTransactionSync.ts
@@ -12,7 +12,7 @@ export const sendTransactionSync = async (
   parameters: SendTransactionSyncParameters,
   options?: SendTransactionSyncOptions
 ): Promise<TransactionReceipt> => {
-  const { calls } = parameters;
+  const { calls, gas, skipSimulation } = parameters;
 
   const [nonce, deployed] = await Promise.all([
     parameters.nonce ?? account.getNonce({ key: parameters.nonceKey }),
@@ -29,6 +29,8 @@ export const sendTransactionSync = async (
       authorizationList,
       chainId: account.chain.id,
       data,
+      gas,
+      skipSimulation,
       to: account.address
     },
     options

--- a/src/relayer/evm/actions/sendTransaction.test.ts
+++ b/src/relayer/evm/actions/sendTransaction.test.ts
@@ -69,6 +69,31 @@ describe('sendTransaction', () => {
     ).rejects.toThrow();
   });
 
+  it('includes gas and skipSimulation in RPC params when provided', async () => {
+    const { client, request } = createMockTransportClient();
+    request.mockResolvedValue(MOCK_TX_HASH);
+
+    await sendTransaction(client, {
+      chainId: 1,
+      data: MOCK_CALL_DATA,
+      gas: 100000n,
+      skipSimulation: true,
+      to: MOCK_ADDRESS
+    });
+
+    expect(request).toHaveBeenCalledWith({
+      method: 'relayer_sendTransaction',
+      params: {
+        authorizationList: undefined,
+        chainId: '1',
+        data: MOCK_CALL_DATA,
+        gas: '100000',
+        skipSimulation: true,
+        to: MOCK_ADDRESS
+      }
+    });
+  });
+
   it('retries on matching error code and succeeds on retry', async () => {
     const { client, request } = createMockTransportClient();
     request

--- a/src/relayer/evm/actions/sendTransaction.ts
+++ b/src/relayer/evm/actions/sendTransaction.ts
@@ -11,6 +11,8 @@ export type SendTransactionParameters = {
   authorizationList?: SignedAuthorizationList;
   chainId: number;
   data: Hex;
+  gas?: bigint;
+  skipSimulation?: boolean;
   to: Address;
 };
 
@@ -23,7 +25,7 @@ export const sendTransaction = async (
   parameters: SendTransactionParameters,
   options?: SendTransactionOptions
 ): Promise<Hex> => {
-  const { chainId, data, to, authorizationList } = parameters;
+  const { chainId, data, to, authorizationList, gas, skipSimulation } = parameters;
   const { retries } = options || {};
 
   return withRetries(async () => {
@@ -36,6 +38,8 @@ export const sendTransaction = async (
             : undefined,
           chainId: chainId.toString(),
           data,
+          gas: gas?.toString(),
+          skipSimulation,
           to
         }
       });

--- a/src/relayer/evm/actions/sendTransactionSync.test.ts
+++ b/src/relayer/evm/actions/sendTransactionSync.test.ts
@@ -99,6 +99,33 @@ describe('sendTransactionSync', () => {
     await expect(sendTransactionSync(client, baseParams)).rejects.toThrow();
   });
 
+  it('includes gas and skipSimulation in RPC params when provided', async () => {
+    const { client, request } = createMockTransportClient();
+    request.mockResolvedValue({
+      chainId: 1,
+      createdAt: 1700000000,
+      id: MOCK_ID,
+      receipt: mockRpcTransactionReceipt(),
+      status: StatusCode.Success
+    });
+
+    await sendTransactionSync(client, {
+      ...baseParams,
+      gas: 100000n,
+      skipSimulation: true
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          gas: '100000',
+          skipSimulation: true
+        })
+      }),
+      expect.anything()
+    );
+  });
+
   it('retries on matching error code and succeeds on retry', async () => {
     const { client, request } = createMockTransportClient();
     request

--- a/src/relayer/evm/actions/sendTransactionSync.ts
+++ b/src/relayer/evm/actions/sendTransactionSync.ts
@@ -39,7 +39,7 @@ export const sendTransactionSync = async (
   parameters: SendTransactionParameters,
   options?: SendTransactionSyncOptions
 ): Promise<TransactionReceipt> => {
-  const { chainId, data, to, authorizationList } = parameters;
+  const { chainId, data, to, authorizationList, gas, skipSimulation } = parameters;
 
   const {
     timeout = 120000,
@@ -61,6 +61,8 @@ export const sendTransactionSync = async (
               : undefined,
             chainId: chainId.toString(),
             data,
+            gas: gas?.toString(),
+            skipSimulation,
             // Always select the minimum timeout, either the http client timeout or the request timeout
             // The request timeout must always be greater so we can then parse the transaction id from the error
             // Otherwise the the http client will timeout locally


### PR DESCRIPTION
## Summary
- Add optional `gas` (bigint) and `skipSimulation` (boolean) parameters to `sendTransaction` and `sendTransactionSync` across relayer and account layers
- Values are passed through to the RPC request params (`gas` is converted to string)
- Add tests for both new parameters at all layers

## Test plan
- [x] All existing tests pass (`pnpm test` — 202 tests)
- [x] Build and type-check pass (`pnpm build`, `tsc --noEmit`)
- [x] New tests verify `gas` and `skipSimulation` are included in RPC params (relayer layer)
- [x] New tests verify `gas` and `skipSimulation` are passed through to client (account layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)